### PR TITLE
free pFlac in drflac_close

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -2581,6 +2581,8 @@ void drflac_close(drflac* pFlac)
     if (pFlac->onRead == drflac__on_read_memory) {
         free(pFlac->pUserData);
     }
+
+    free(pFlac);
 }
 
 uint64_t drflac__read_s32__misaligned(drflac* pFlac, uint64_t samplesToRead, int32_t* bufferOut)


### PR DESCRIPTION
I'm not sure if this was intentional or not, but drflac_close doesn't actually free the structure.  Since drflac_open allocates it, it seems intuitive to me that drflac_close should free it again.