### PR TITLE
Fix version check for pre-gcc 4.3

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -682,7 +682,7 @@ static DRFLAC_INLINE uint16_t drflac__swap_endian_uint16(uint16_t n)
 {
 #ifdef _MSC_VER
     return _byteswap_ushort(n);
-#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC__ >= 3))
+#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
     return __builtin_bswap16(n);
 #else
     return ((n & 0xFF00) >> 8) |
@@ -694,7 +694,7 @@ static DRFLAC_INLINE uint32_t drflac__swap_endian_uint32(uint32_t n)
 {
 #ifdef _MSC_VER
     return _byteswap_ulong(n);
-#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC__ >= 3))
+#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
     return __builtin_bswap32(n);
 #else
     return ((n & 0xFF000000) >> 24) |
@@ -708,7 +708,7 @@ static DRFLAC_INLINE uint64_t drflac__swap_endian_uint64(uint64_t n)
 {
 #ifdef _MSC_VER
     return _byteswap_uint64(n);
-#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC__ >= 3))
+#elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
     return __builtin_bswap64(n);
 #else
     return ((n & 0xFF00000000000000ULL) >> 56) |


### PR DESCRIPTION
This fixes a compilation issue in gcc versions before 4.3 caused by a copy&paste error in a preprocessor comparison.