### PR TITLE
sequential write

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -111,7 +111,7 @@
 // - This has not been tested on big-endian architectures.
 // - Rice codes in unencoded binary form (see https://xiph.org/flac/format.html#rice_partition) has not been tested. If anybody
 //   knows where I can find some test files for this, let me know.
-// - dr_flac is not thread-safe, but it's APIs can be called from any thread so long as you do your own synchronization.
+// - dr_flac is not thread-safe, but its APIs can be called from any thread so long as you do your own synchronization.
 // - When using Ogg encapsulation, a corrupted metadata block will result in drflac_open_with_metadata() and drflac_open()
 //   returning inconsistent samples.
 
@@ -467,7 +467,7 @@ typedef struct
     // value specified in the STREAMINFO block.
     drflac_uint8 channels;
 
-    // The bits per sample. Will be set to somthing like 16, 24, etc.
+    // The bits per sample. Will be set to something like 16, 24, etc.
     drflac_uint8 bitsPerSample;
 
     // The maximum block size, in samples. This number represents the number of samples in each channel (not combined).
@@ -579,7 +579,7 @@ drflac* drflac_open_relaxed(drflac_read_proc onRead, drflac_seek_proc onSeek, dr
 // See also: drflac_open_file_with_metadata(), drflac_open_memory_with_metadata(), drflac_open(), drflac_close()
 drflac* drflac_open_with_metadata(drflac_read_proc onRead, drflac_seek_proc onSeek, drflac_meta_proc onMeta, void* pUserData);
 
-// The same as drflac_open_with_metadata(), except attemps to open the stream even when a header block is not present.
+// The same as drflac_open_with_metadata(), except attempts to open the stream even when a header block is not present.
 //
 // See also: drflac_open_with_metadata(), drflac_open_relaxed()
 drflac* drflac_open_with_metadata_relaxed(drflac_read_proc onRead, drflac_seek_proc onSeek, drflac_meta_proc onMeta, drflac_container container, void* pUserData);
@@ -3175,10 +3175,10 @@ static drflac_bool32 drflac__seek_to_sample__brute_force(drflac* pFlac, drflac_u
 
     drflac_bool32 isMidFrame = DRFLAC_FALSE;
 
-    // If we are seeking foward we start from the current position. Otherwise we need to start all the way from the start of the file.
+    // If we are seeking forward we start from the current position. Otherwise we need to start all the way from the start of the file.
     drflac_uint64 runningSampleCount;
     if (sampleIndex >= pFlac->currentSample) {
-        // Seeking foward. Need to seek from the current position.
+        // Seeking forward. Need to seek from the current position.
         runningSampleCount = pFlac->currentSample;
 
         // The frame header for the first frame may not yet have been read. We need to do that if necessary.
@@ -3204,7 +3204,7 @@ static drflac_bool32 drflac__seek_to_sample__brute_force(drflac* pFlac, drflac_u
         }
     }
 
-    // We need to as quickly as possible find the frame that contains the target sample. To do this, we iterate over each frame and inspect it's
+    // We need to as quickly as possible find the frame that contains the target sample. To do this, we iterate over each frame and inspect its
     // header. If based on the header we can determine that the frame contains the sample, we do a full decode of that frame.
     for (;;) {
         drflac_uint64 firstSampleInFrame = 0;
@@ -3657,7 +3657,7 @@ drflac_bool32 drflac__read_and_decode_metadata(drflac_read_proc onRead, drflac_s
 
                     // Padding doesn't have anything meaningful in it, so just skip over it, but make sure the caller is aware of it by firing the callback.
                     if (!onSeek(pUserData, blockSize, drflac_seek_origin_current)) {
-                        isLastBlock = DRFLAC_TRUE;  // An error occured while seeking. Attempt to recover by treating this as the last block which will in turn terminate the loop.
+                        isLastBlock = DRFLAC_TRUE;  // An error occurred while seeking. Attempt to recover by treating this as the last block which will in turn terminate the loop.
                     } else {
                         onMeta(pUserDataMD, &metadata);
                     }
@@ -3669,7 +3669,7 @@ drflac_bool32 drflac__read_and_decode_metadata(drflac_read_proc onRead, drflac_s
                 // Invalid chunk. Just skip over this one.
                 if (onMeta) {
                     if (!onSeek(pUserData, blockSize, drflac_seek_origin_current)) {
-                        isLastBlock = DRFLAC_TRUE;  // An error occured while seeking. Attempt to recover by treating this as the last block which will in turn terminate the loop.
+                        isLastBlock = DRFLAC_TRUE;  // An error occurred while seeking. Attempt to recover by treating this as the last block which will in turn terminate the loop.
                     }
                 }
             } break;
@@ -4003,7 +4003,7 @@ drflac_result drflac_ogg__read_page_header(drflac_read_proc onRead, void* pUserD
 
 
 // The main part of the Ogg encapsulation is the conversion from the physical Ogg bitstream to the native FLAC bitstream. It works
-// in three general stages: Ogg Physical Bitstream -> Ogg/FLAC Logical Bitstream -> FLAC Native Bitstream. dr_flac is architecured
+// in three general stages: Ogg Physical Bitstream -> Ogg/FLAC Logical Bitstream -> FLAC Native Bitstream. dr_flac is designed
 // in such a way that the core sections assume everything is delivered in native format. Therefore, for each encapsulation type
 // dr_flac is supporting there needs to be a layer sitting on top of the onRead and onSeek callbacks that ensures the bits read from
 // the physical Ogg bitstream are converted and delivered in native FLAC format.
@@ -4351,13 +4351,13 @@ drflac_bool32 drflac_ogg__seek_to_sample(drflac* pFlac, drflac_uint64 sampleInde
         //
         // Another thing to consider is that using the Ogg framing system will perform direct seeking of the physical Ogg
         // bitstream. This is important to consider because it means we cannot read data from the drflac_bs object using the
-        // standard drflac__*() APIs because that will read in extra data for it's own internal caching which in turn breaks
+        // standard drflac__*() APIs because that will read in extra data for its own internal caching which in turn breaks
         // the positioning of the read pointer of the physical Ogg bitstream. Therefore, anything that would normally be read
         // using the native FLAC decoding APIs, such as drflac__read_next_frame_header(), need to be re-implemented so as to
         // avoid the use of the drflac_bs object.
         //
         // Considering these issues, I have decided to use the slower native FLAC decoding method for the following reasons:
-        //   1) Seeking is already partially accellerated using Ogg's paging system in the code block above.
+        //   1) Seeking is already partially accelerated using Ogg's paging system in the code block above.
         //   2) Seeking in an Ogg encapsulated FLAC stream is probably quite uncommon.
         //   3) Simplicity.
         if (!drflac__read_next_frame_header(&pFlac->bs, pFlac->bitsPerSample, &pFlac->currentFrame.header)) {
@@ -4550,7 +4550,7 @@ drflac_bool32 drflac__init_private__ogg(drflac_init_info* pInit, drflac_read_pro
 
 
     // If we get here it means we found a FLAC audio stream. We should be sitting on the first byte of the header of the next page. The next
-    // packets in the FLAC logical stream contain the metadata. The only thing left to do in the initialiation phase for Ogg is to create the
+    // packets in the FLAC logical stream contain the metadata. The only thing left to do in the initialization phase for Ogg is to create the
     // Ogg bistream object.
     pInit->hasMetadataBlocks = DRFLAC_TRUE;    // <-- Always have at least VORBIS_COMMENT metadata block.
     return DRFLAC_TRUE;
@@ -4758,7 +4758,7 @@ drflac* drflac_open_with_metadata_private(drflac_read_proc onRead, drflac_seek_p
 
     pFlac->firstFramePos = firstFramePos;
 
-    // NOTE: Seektables are not currently compatible with Ogg encapsulation (Ogg has it's own accelerated seeking system). I may change this later, so I'm leaving this here for now.
+    // NOTE: Seektables are not currently compatible with Ogg encapsulation (Ogg has its own accelerated seeking system). I may change this later, so I'm leaving this here for now.
 #ifndef DR_FLAC_NO_OGG
     if (init.container == drflac_container_ogg)
     {

--- a/dr_math.h
+++ b/dr_math.h
@@ -1,10 +1,10 @@
 // Public Domain. See "unlicense" statement at the end of this file.
 
 // NOTE: This is still very much work in progress and is only being updated as I need it. You don't want to be using this library
-//       in it's current state.
+//       in its current state.
 
 // QUICK NOTES
-// - This library does not use SSE for it's basic types (vec4, etc.). Rationale: 1) It keeps things simple; 2) SSE is not always
+// - This library does not use SSE for its basic types (vec4, etc.). Rationale: 1) It keeps things simple; 2) SSE is not always
 //   faster than the FPU(s) on modern CPUs; 3) The library can always implement functions that work on __m128 variables directly
 //   in the future if the need arises; 4) It doesn't work well with the pass-by-value API this library uses.
 // - Use DISABLE_SSE to disable SSE optimized functions.

--- a/dr_obj.h
+++ b/dr_obj.h
@@ -1143,7 +1143,7 @@ dr_bool32 drobj__load_stage2(drobj* pOBJ, drobj_load_context* pLoadContext)
             pOBJ->pMaterials[pLoadContext->materialCount].firstFace = pLoadContext->faceCount;
             pOBJ->pMaterials[pLoadContext->materialCount].faceCount = 0;
 
-            // Previous material needs to have it's face count updated.
+            // Previous material needs to have its face count updated.
             if (pLoadContext->materialCount > 0) {
                 pOBJ->pMaterials[pLoadContext->materialCount-1].faceCount = pLoadContext->faceCount - pOBJ->pMaterials[pLoadContext->materialCount-1].firstFace;
             }
@@ -1161,7 +1161,7 @@ dr_bool32 drobj__load_stage2(drobj* pOBJ, drobj_load_context* pLoadContext)
         }
     }
 
-    // Previous material needs to have it's face count updated.
+    // Previous material needs to have its face count updated.
     if (pLoadContext->materialCount > 0) {
         pOBJ->pMaterials[pLoadContext->materialCount-1].faceCount = pLoadContext->faceCount - pOBJ->pMaterials[pLoadContext->materialCount-1].firstFace;
     }

--- a/dr_wav.h
+++ b/dr_wav.h
@@ -50,7 +50,7 @@
 //     drwav_free(pSampleData);
 //
 // The examples above use versions of the API that convert the audio data to a consistent format (32-bit signed PCM, in
-// this case), but you can still output the audio data in it's internal format (see notes below for supported formats):
+// this case), but you can still output the audio data in its internal format (see notes below for supported formats):
 //
 //     size_t samplesRead = drwav_read(&wav, wav.totalSampleCount, pDecodedInterleavedSamples);
 //
@@ -246,7 +246,7 @@ typedef struct
     // Block align. This is equal to the number of channels * bytes per sample.
     drwav_uint16 blockAlign;
 
-    // Bit's per sample.
+    // Bits per sample.
     drwav_uint16 bitsPerSample;
 
     // The size of the extended data. Only used internally for validation, but left here for informational purposes.
@@ -292,7 +292,7 @@ typedef struct
     // The number of channels. This will be set to 1 for monaural streams, 2 for stereo, etc.
     drwav_uint16 channels;
 
-    // The bits per sample. Will be set to somthing like 16, 24, etc.
+    // The bits per sample. Will be set to something like 16, 24, etc.
     drwav_uint16 bitsPerSample;
 
     // The number of bytes per sample.
@@ -491,7 +491,7 @@ drwav_uint64 drwav_write(drwav* pWav, drwav_uint64 samplesToWrite, const void* p
 
 
 
-//// Convertion Utilities ////
+//// Conversion Utilities ////
 #ifndef DR_WAV_NO_CONVERSION_API
 
 // Reads a chunk of audio data and converts it to signed 16-bit PCM samples.
@@ -1582,8 +1582,8 @@ drwav_bool32 drwav_init(drwav* pWav, drwav_read_proc onRead, drwav_seek_proc onS
 #ifdef DR_WAV_LIBSNDFILE_COMPAT
     // I use libsndfile as a benchmark for testing, however in the version I'm using (from the Windows installer on the libsndfile website),
     // it appears the total sample count libsndfile uses for MS-ADPCM is incorrect. It would seem they are computing the total sample count
-    // from the number of blocks, however this results in the inclusion of the extra silent samples at the end of the last block. The correct
-    // way to know the total sample count is to inspect the "fact" chunk which should always be present for compressed formats, and should
+    // from the number of blocks, however this results in the inclusion of extra silent samples at the end of the last block. The correct
+    // way to know the total sample count is to inspect the "fact" chunk, which should always be present for compressed formats, and should
     // always include the sample count. This little block of code below is only used to emulate the libsndfile logic so I can properly run my
     // correctness tests against libsndfile, and is disabled by default.
     if (pWav->translatedFormatTag == DR_WAVE_FORMAT_ADPCM) {
@@ -1669,8 +1669,8 @@ drwav_bool32 drwav_init_write__internal(drwav* pWav, const drwav_data_format* pF
 
     size_t runningPos = 0;
 
-    // The initial values for the "RIFF" and "data" chunks dependson whether or not we are initializing in sequential mode or not. In
-    // sequential mode we set this to it's final values straight away since they can be calculated from the total sample count. In non-
+    // The initial values for the "RIFF" and "data" chunks depends on whether or not we are initializing in sequential mode or not. In
+    // sequential mode we set this to its final values straight away since they can be calculated from the total sample count. In non-
     // sequential mode we initialize it all to zero and fill it out in drwav_uninit() using a backwards seek.
     drwav_uint64 initialDataChunkSize = 0;
     if (isSequential) {
@@ -1775,7 +1775,7 @@ void drwav_uninit(drwav* pWav)
         return;
     }
 
-    // If the drwav object was opened in write mode we'll need to finialize a few things:
+    // If the drwav object was opened in write mode we'll need to finalize a few things:
     //   - Make sure the "data" chunk is aligned to 16-bits for RIFF containers, or 64 bits for W64 containers.
     //   - Set the size of the "data" chunk.
     if (pWav->onWrite != NULL) {


### PR DESCRIPTION
# Summary

Allow user to specify the file size up-front for `.wav` file write functions, to allow fully sequential writing to the file. User should set the `totalNumSamples` parameter to 0 to use the prior behavior, where file size is unknown ahead of time.

NEEDS REVIEW! I added the parameter to all the wav file write functions, but only tested it with `drwav_init_file_write()`, `drwav_write()`, and `drwav_uninit()`.

# Motivation

I am creating some `.wav` files with MD5 sums. I am calculating the MD5 sums on-the-fly. The seek back to correct the chunk sizes in `drwav_uninit()` precludes this behavior.

Purely sequential writing is preferable for flash media, too.

# Notes

- In this implementation, if you specify a file size (non-zero `totalNumSamples`) on file write init, then:
    - The `onSeek` function is not required. If provided, it will be ignored.
    - There is no way to correct the size after the fact.
- I added a few little internal helper functions such as `drwav_riff_chunk_size_riff()`. I wasn't sure of your preferred conventions for that type thing, so I didn't comment them, or add declarations up top.
- If you like my idea, but choose to implement it a different way, that's fine by me. I considered adding a parameter to `drwav_data_format`, but didn't do that since this change affects only the process of writing, not the resulting format.
- Looks like you're aiming to support C and C++. If it was C++ only, I would've set the default `totalNumSamples` value to 0. You could add `#ifdef`s on the declarations to do that for C++ only.