### PR TITLE
dr_mp3.h: use emmintrin.h instead of immintrin.h

### DIFF
--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -354,7 +354,7 @@ void drmp3_free(void* p);
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif
-#include <immintrin.h>
+#include <emmintrin.h>
 #define DRMP3_HAVE_SSE 1
 #define DRMP3_HAVE_SIMD 1
 #define DRMP3_VSTORE _mm_storeu_ps


### PR DESCRIPTION
emmintrin.h is available in older gcc versions.
(I needed this when building something with gcc-4.2.1 targeting Darwin.)