### PR TITLE
MSVC2003 doesn't seem to have byte swap intrinsics

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -1187,7 +1187,7 @@ static DRFLAC_INLINE drflac_bool32 drflac_has_sse41()
     #endif
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER >= 1300
+#if defined(_MSC_VER) && _MSC_VER >= 1400
     #define DRFLAC_HAS_BYTESWAP16_INTRINSIC
     #define DRFLAC_HAS_BYTESWAP32_INTRINSIC
     #define DRFLAC_HAS_BYTESWAP64_INTRINSIC

--- a/dr_wav.h
+++ b/dr_wav.h
@@ -1050,7 +1050,7 @@ void drwav_free(void* p, const drwav_allocation_callbacks* pAllocationCallbacks)
     #endif
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER >= 1300
+#if defined(_MSC_VER) && _MSC_VER >= 1400
     #define DRWAV_HAS_BYTESWAP16_INTRINSIC
     #define DRWAV_HAS_BYTESWAP32_INTRINSIC
     #define DRWAV_HAS_BYTESWAP64_INTRINSIC

--- a/wip/dr_opus.h
+++ b/wip/dr_opus.h
@@ -281,7 +281,7 @@ void dropus_uninit(dropus* pOpus);
     #endif
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER >= 1300
+#if defined(_MSC_VER) && _MSC_VER >= 1400
     #define DROPUS_HAS_BYTESWAP16_INTRINSIC
     #define DROPUS_HAS_BYTESWAP32_INTRINSIC
     #define DROPUS_HAS_BYTESWAP64_INTRINSIC


### PR DESCRIPTION
Compiling dr_wav and dr_flac with Visual Studio .NET 2003 gives me errors about `_byteswap_ushort` not being found. It'd be nice if Microsoft's docs pointed out when that was added, but a quick search turned up nothing.