### PR TITLE
dr_mp3: Fix error with `DR_MP3_NO_STDIO`

### DIFF
--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -2465,8 +2465,6 @@ static void drmp3__free_default(void* p, void* pUserData)
 }
 
 
-/* Only used without DR_MP3_NO_STDIO. */
-#ifndef DR_MP3_NO_STDIO
 static void* drmp3__malloc_from_callbacks(size_t sz, const drmp3_allocation_callbacks* pAllocationCallbacks)
 {
     if (pAllocationCallbacks == NULL) {
@@ -2484,7 +2482,6 @@ static void* drmp3__malloc_from_callbacks(size_t sz, const drmp3_allocation_call
 
     return NULL;
 }
-#endif
 
 static void* drmp3__realloc_from_callbacks(void* p, size_t szNew, size_t szOld, const drmp3_allocation_callbacks* pAllocationCallbacks)
 {


### PR DESCRIPTION
This is related to #125.

cfc9a39178e6f2349ce28ca5c09a93217b680957 seems to be the commit that caused the bug, rather than what fixed it.