### PR TITLE
Added the old size as a parameter to the onRealloc callbacks

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -561,7 +561,7 @@ typedef struct
 {
     void* pUserData;
     void* (* onMalloc)(size_t sz, void* pUserData);
-    void* (* onRealloc)(void* p, size_t sz, void* pUserData);
+    void* (* onRealloc)(void* p, size_t szNew, size_t szOld, void* pUserData);
     void  (* onFree)(void* p, void* pUserData);
 } drflac_allocation_callbacks;
 
@@ -6198,10 +6198,11 @@ static void* drflac__malloc_default(size_t sz, void* pUserData)
     return DRFLAC_MALLOC(sz);
 }
 
-static void* drflac__realloc_default(void* p, size_t sz, void* pUserData)
+static void* drflac__realloc_default(void* p, size_t szNew, size_t szOld, void* pUserData)
 {
     (void)pUserData;
-    return DRFLAC_REALLOC(p, sz);
+    (void)szOld;
+    return DRFLAC_REALLOC(p, szNew);
 }
 
 static void drflac__free_default(void* p, void* pUserData)
@@ -6223,7 +6224,7 @@ static void* drflac__malloc_from_callbacks(size_t sz, const drflac_allocation_ca
 
     /* Try using realloc(). */
     if (pAllocationCallbacks->onRealloc != NULL) {
-        return pAllocationCallbacks->onRealloc(NULL, sz, pAllocationCallbacks->pUserData);
+        return pAllocationCallbacks->onRealloc(NULL, sz, 0, pAllocationCallbacks->pUserData);
     }
 
     return NULL;
@@ -6236,7 +6237,7 @@ static void* drflac__realloc_from_callbacks(void* p, size_t szNew, size_t szOld,
     }
 
     if (pAllocationCallbacks->onRealloc != NULL) {
-        return pAllocationCallbacks->onRealloc(p, szNew, pAllocationCallbacks->pUserData);
+        return pAllocationCallbacks->onRealloc(p, szNew, szOld, pAllocationCallbacks->pUserData);
     }
 
     /* Try emulating realloc() in terms of malloc()/free(). */

--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -333,7 +333,7 @@ typedef struct
 {
     void* pUserData;
     void* (* onMalloc)(size_t sz, void* pUserData);
-    void* (* onRealloc)(void* p, size_t sz, void* pUserData);
+    void* (* onRealloc)(void* p, size_t szNew, size_t szOld, void* pUserData);
     void  (* onFree)(void* p, void* pUserData);
 } drmp3_allocation_callbacks;
 
@@ -2487,10 +2487,11 @@ static void* drmp3__malloc_default(size_t sz, void* pUserData)
     return DRMP3_MALLOC(sz);
 }
 
-static void* drmp3__realloc_default(void* p, size_t sz, void* pUserData)
+static void* drmp3__realloc_default(void* p, size_t szNew, size_t szOld, void* pUserData)
 {
     (void)pUserData;
-    return DRMP3_REALLOC(p, sz);
+    (void)szOld;
+    return DRMP3_REALLOC(p, szNew);
 }
 
 static void drmp3__free_default(void* p, void* pUserData)
@@ -2512,7 +2513,7 @@ static void* drmp3__malloc_from_callbacks(size_t sz, const drmp3_allocation_call
 
     /* Try using realloc(). */
     if (pAllocationCallbacks->onRealloc != NULL) {
-        return pAllocationCallbacks->onRealloc(NULL, sz, pAllocationCallbacks->pUserData);
+        return pAllocationCallbacks->onRealloc(NULL, sz, 0, pAllocationCallbacks->pUserData);
     }
 
     return NULL;
@@ -2525,7 +2526,7 @@ static void* drmp3__realloc_from_callbacks(void* p, size_t szNew, size_t szOld, 
     }
 
     if (pAllocationCallbacks->onRealloc != NULL) {
-        return pAllocationCallbacks->onRealloc(p, szNew, pAllocationCallbacks->pUserData);
+        return pAllocationCallbacks->onRealloc(p, szNew, szOld, pAllocationCallbacks->pUserData);
     }
 
     /* Try emulating realloc() in terms of malloc()/free(). */

--- a/dr_wav.h
+++ b/dr_wav.h
@@ -433,7 +433,7 @@ typedef struct
 {
     void* pUserData;
     void* (* onMalloc)(size_t sz, void* pUserData);
-    void* (* onRealloc)(void* p, size_t sz, void* pUserData);
+    void* (* onRealloc)(void* p, size_t szNew, size_t szOld, void* pUserData);
     void  (* onFree)(void* p, void* pUserData);
 } drwav_allocation_callbacks;
 
@@ -1424,10 +1424,11 @@ static void* drwav__malloc_default(size_t sz, void* pUserData)
     return DRWAV_MALLOC(sz);
 }
 
-static void* drwav__realloc_default(void* p, size_t sz, void* pUserData)
+static void* drwav__realloc_default(void* p, size_t szNew, size_t szOld, void* pUserData)
 {
     (void)pUserData;
-    return DRWAV_REALLOC(p, sz);
+    (void)szOld;
+    return DRWAV_REALLOC(p, szNew);
 }
 
 static void drwav__free_default(void* p, void* pUserData)
@@ -1449,7 +1450,7 @@ static void* drwav__malloc_from_callbacks(size_t sz, const drwav_allocation_call
 
     /* Try using realloc(). */
     if (pAllocationCallbacks->onRealloc != NULL) {
-        return pAllocationCallbacks->onRealloc(NULL, sz, pAllocationCallbacks->pUserData);
+        return pAllocationCallbacks->onRealloc(NULL, sz, 0, pAllocationCallbacks->pUserData);
     }
 
     return NULL;
@@ -1462,7 +1463,7 @@ static void* drwav__realloc_from_callbacks(void* p, size_t szNew, size_t szOld, 
     }
 
     if (pAllocationCallbacks->onRealloc != NULL) {
-        return pAllocationCallbacks->onRealloc(p, szNew, pAllocationCallbacks->pUserData);
+        return pAllocationCallbacks->onRealloc(p, szNew, szOld, pAllocationCallbacks->pUserData);
     }
 
     /* Try emulating realloc() in terms of malloc()/free(). */


### PR DESCRIPTION
I ran the tests as well but only `[dr_mp3_test_0.exe,  dr_wav_test_0.exe,  dr_wav_test_0_cpp.exe]` compiled successfully however the compilation errors were not related to my changes so they should be fine.