### PR TITLE
dr_mp3: Uninitialize after failing allocation checks.

### DIFF
--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -2826,6 +2826,7 @@ static drmp3_bool32 drmp3_init_internal(drmp3* pMP3, drmp3_read_proc onRead, drm
     pMP3->allocationCallbacks = drmp3_copy_allocation_callbacks_or_defaults(pAllocationCallbacks);
 
     if (pMP3->allocationCallbacks.onFree == NULL || (pMP3->allocationCallbacks.onMalloc == NULL && pMP3->allocationCallbacks.onRealloc == NULL)) {
+        drmp3_uninit(pMP3);
         return DRMP3_FALSE;    /* Invalid allocation callbacks. */
     }
 
@@ -3487,38 +3488,24 @@ static drmp3_bool32 drmp3__on_seek_stdio(void* pUserData, int offset, drmp3_seek
 
 DRMP3_API drmp3_bool32 drmp3_init_file(drmp3* pMP3, const char* pFilePath, const drmp3_allocation_callbacks* pAllocationCallbacks)
 {
-    drmp3_bool32 result;
     FILE* pFile;
 
     if (drmp3_fopen(&pFile, pFilePath, "rb") != DRMP3_SUCCESS) {
         return DRMP3_FALSE;
     }
 
-    result = drmp3_init(pMP3, drmp3__on_read_stdio, drmp3__on_seek_stdio, (void*)pFile, pAllocationCallbacks);
-    if (result != DRMP3_TRUE) {
-        fclose(pFile);
-        return result;
-    }
-
-    return DRMP3_TRUE;
+    return drmp3_init(pMP3, drmp3__on_read_stdio, drmp3__on_seek_stdio, (void*)pFile, pAllocationCallbacks);
 }
 
 DRMP3_API drmp3_bool32 drmp3_init_file_w(drmp3* pMP3, const wchar_t* pFilePath, const drmp3_allocation_callbacks* pAllocationCallbacks)
 {
-    drmp3_bool32 result;
     FILE* pFile;
 
     if (drmp3_wfopen(&pFile, pFilePath, L"rb", pAllocationCallbacks) != DRMP3_SUCCESS) {
         return DRMP3_FALSE;
     }
 
-    result = drmp3_init(pMP3, drmp3__on_read_stdio, drmp3__on_seek_stdio, (void*)pFile, pAllocationCallbacks);
-    if (result != DRMP3_TRUE) {
-        fclose(pFile);
-        return result;
-    }
-
-    return DRMP3_TRUE;
+    return drmp3_init(pMP3, drmp3__on_read_stdio, drmp3__on_seek_stdio, (void*)pFile, pAllocationCallbacks);
 }
 #endif
 


### PR DESCRIPTION
Coverity warns in #171 that `drmp3_init_file` tries to  call `fclose` on an already-freed `pFile`.  I originally though we could simple check if `pFile != NULL` and call `fclose`, however there's no way for  `drmp3_init` to update pFile's value because it's passed in as a value (not as a reference or pointer).  

The solution involved uninitializing the pMP3 structure in /both/ places where initialization fails, in which case we can be sure that pFile is handled properly in all positive and failure scenarios. 

Fixes #171