### PR TITLE
dr_flac: Remove comparison that is always true

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -5170,7 +5170,8 @@ static drflac_bool32 drflac__read_next_flac_frame_header(drflac_bs* bs, drflac_u
         DRFLAC_ASSERT(blockSize > 0);
         if (blockSize == 1) {
             header->blockSizeInPCMFrames = 192;
-        } else if (blockSize >= 2 && blockSize <= 5) {
+        } else if (blockSize <= 5) {
+            DRFLAC_ASSERT(blockSize >= 2);
             header->blockSizeInPCMFrames = 576 * (1 << (blockSize - 2));
         } else if (blockSize == 6) {
             if (!drflac__read_uint16(bs, 8, &header->blockSizeInPCMFrames)) {


### PR DESCRIPTION
Comparison is always true, because code above returns early when
unsigned blockSize is 0. This invariant is asserted just before
if-else chain.

---
This is a follow up to #176 - to present an alternative fix. I also experimented with replacing these if-else's with a switch statement, but replacing this single comparison with an assert is less invasive change, and more readable.