### PR TITLE
dr_flac: tests - build_flac_linux fix and improvement. Add flac tests to README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ tests/bin/*
 tests/build
 tests/flac/include
 tests/flac/lib
+tests/testvectors/flac/tests/*
+!tests/testvectors/flac/tests/DO_NOT_DELETE.md
 todo

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,4 +45,4 @@ Opus
 
 Flac
 ---
-- Download test flacs from https://media.xiph.org/ and place into testvectors/flac/tests.
+- Download test flacs from https://media.xiph.org/ and place them into the "testvectors/flac/tests" folder.

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,3 +42,7 @@ Opus
       - oggopus
         - failure_cases
         - opus_multichannel_examples
+
+Flac
+---
+- Download test flacs from https://media.xiph.org/ and place into testvectors/flac/tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,4 +45,4 @@ Opus
 
 Flac
 ---
-- Download test flacs from https://media.xiph.org/ and place into testvectors/flac/tests
+- Download test flacs from https://media.xiph.org/ and place into testvectors/flac/tests.

--- a/tests/build_flac_linux.sh
+++ b/tests/build_flac_linux.sh
@@ -1,3 +1,4 @@
-gcc ./flac/dr_flac_test_0.c -o ./bin/dr_flac_test_0 -std=c89 -ansi -pedantic -03 -s -Wall
+#!/bin/sh
+gcc ./flac/dr_flac_test_0.c -o ./bin/dr_flac_test_0 -std=c89 -ansi -pedantic -O3 -s -Wall -ldl
 gcc ./flac/dr_flac_decoding.c -o ./bin/dr_flac_decoding -std=c89 -ansi -pedantic -Wall -O3 -s -lFLAC -ldl
 gcc ./flac/dr_flac_seeking.c -o ./bin/dr_flac_seeking -std=c89 -ansi -pedantic -Wall -O3 -s -lFLAC -ldl


### PR DESCRIPTION
Fixes:
```
/tmp/ccLFJs1C.o: In function `dr_dlopen':
dr_flac_test_0.c:(.text+0x1d1f6): undefined reference to `dlopen'
/tmp/ccLFJs1C.o: In function `dr_dlclose':
dr_flac_test_0.c:(.text+0x1d201): undefined reference to `dlclose'
/tmp/ccLFJs1C.o: In function `dr_dlsym':
dr_flac_test_0.c:(.text+0x1d211): undefined reference to `dlsym'
collect2: error: ld returned 1 exit status
```
build_flac_linux changed to follow documentation and linux convention.
Info on testing flac added to README.md.  
