### PR TITLE
Also try dlopen’ing libsndfile.so.1, which will often work on Linux

### DIFF
--- a/tests/wav/dr_wav_common.c
+++ b/tests/wav/dr_wav_common.c
@@ -33,7 +33,8 @@ drwav_result libsndfile_init_api()
     #endif
         "libsndfile-1.dll"
 #else
-        "libsndfile-1.so"
+        "libsndfile-1.so",
+        "libsndfile.so.1"
 #endif
     };
 


### PR DESCRIPTION
This will usually allow the tests to work with a system-wide installation of libsndfile without further fuss.