### PR TITLE
Fix loading mp3 file from memory

### DIFF
--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -2250,7 +2250,7 @@ DRMP3_API void drmp3dec_init(drmp3dec *dec)
 
 DRMP3_API int drmp3dec_decode_frame(drmp3dec *dec, const drmp3_uint8 *mp3, int mp3_bytes, void *pcm, drmp3dec_frame_info *info)
 {
-    int i = 0, igr, frame_size = 0, success = 1;
+    int i = 0, igr, frame_size = 0, success = 1, result = 0;
     const drmp3_uint8 *hdr;
     drmp3_bs bs_frame[1];
     drmp3dec_scratch scratch;
@@ -2296,7 +2296,7 @@ DRMP3_API int drmp3dec_decode_frame(drmp3dec *dec, const drmp3_uint8 *mp3, int m
             drmp3dec_init(dec);
             return 0;
         }
-        int result = drmp3_L3_restore_reservoir(dec, bs_frame, &scratch, main_data_begin);
+        result = drmp3_L3_restore_reservoir(dec, bs_frame, &scratch, main_data_begin);
         if (result && pcm != NULL)
         {
             for (igr = 0; igr < (DRMP3_HDR_TEST_MPEG1(hdr) ? 2 : 1); igr++, pcm = DRMP3_OFFSET_PTR(pcm, sizeof(drmp3d_sample_t)*576*info->channels))

--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -2250,7 +2250,7 @@ DRMP3_API void drmp3dec_init(drmp3dec *dec)
 
 DRMP3_API int drmp3dec_decode_frame(drmp3dec *dec, const drmp3_uint8 *mp3, int mp3_bytes, void *pcm, drmp3dec_frame_info *info)
 {
-    int i = 0, igr, frame_size = 0, success = 1, result = 0;
+    int i = 0, igr, frame_size = 0, success = 1;
     const drmp3_uint8 *hdr;
     drmp3_bs bs_frame[1];
     drmp3dec_scratch scratch;
@@ -2291,6 +2291,7 @@ DRMP3_API int drmp3dec_decode_frame(drmp3dec *dec, const drmp3_uint8 *mp3, int m
     if (info->layer == 3)
     {
         int main_data_begin = drmp3_L3_read_side_info(bs_frame, scratch.gr_info, hdr);
+        int result;
         if (main_data_begin < 0 || bs_frame->pos > bs_frame->limit)
         {
             drmp3dec_init(dec);

--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -2296,8 +2296,8 @@ DRMP3_API int drmp3dec_decode_frame(drmp3dec *dec, const drmp3_uint8 *mp3, int m
             drmp3dec_init(dec);
             return 0;
         }
-        success = drmp3_L3_restore_reservoir(dec, bs_frame, &scratch, main_data_begin);
-        if (success && pcm != NULL)
+        int result = drmp3_L3_restore_reservoir(dec, bs_frame, &scratch, main_data_begin);
+        if (result && pcm != NULL)
         {
             for (igr = 0; igr < (DRMP3_HDR_TEST_MPEG1(hdr) ? 2 : 1); igr++, pcm = DRMP3_OFFSET_PTR(pcm, sizeof(drmp3d_sample_t)*576*info->channels))
             {


### PR DESCRIPTION
Top variable `success` is used for local branch check, what leads to incorrect behavior and impossible to load well formed MP3 file. Example MP3 file is attached for testing.
[Kalimba.mp3.zip](https://github.com/mackron/dr_libs/files/6992505/Kalimba.mp3.zip)
