### PR TITLE
dr_flac: Do not use the seektable if pcmFramIndex is not coverd by it.

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -6013,6 +6013,11 @@ static drflac_bool32 drflac__seek_to_pcm_frame__seek_table(drflac* pFlac, drflac
         return DRFLAC_FALSE;
     }
 
+    /* Do not use the seektable if pcmFramIndex is not coverd by it. */
+    if (pFlac->pSeekpoints[0].firstPCMFrame > pcmFrameIndex) {
+        return DRFLAC_FALSE;
+    }
+
     for (iSeekpoint = 0; iSeekpoint < pFlac->seekpointCount; ++iSeekpoint) {
         if (pFlac->pSeekpoints[iSeekpoint].firstPCMFrame >= pcmFrameIndex) {
             break;


### PR DESCRIPTION
The seektable of some `.flac` files might start with a pcm frame greater then 0. Therefore a requested `pcmFrameIndex` could be from before the beginning of the seektable. This in turn confuses the computation of `byteRangeLo` and `byteRangeHigh` down the road.

This is a simple fix of the issue by early returning from `drflac__seek_to_pcm_frame__seek_table(...)` to fall back to the next available seek method. I guess the best would be to always fall back to the brute force method, right?