### PR TITLE
Add FLAC fuzzer and fix found bugs

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -5380,6 +5380,11 @@ static drflac_bool32 drflac__decode_subframe(drflac_bs* bs, drflac_frame* frame,
         subframeBitsPerSample += 1;
     }
 
+    if (subframeBitsPerSample > 32) {
+        /* libFLAC and ffmpeg reject 33-bit subframes as well */
+        return DRFLAC_FALSE;
+    }
+
     /* Need to handle wasted bits per sample. */
     if (pSubframe->wastedBitsPerSample >= subframeBitsPerSample) {
         return DRFLAC_FALSE;

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -5253,6 +5253,9 @@ static drflac_bool32 drflac__read_next_flac_frame_header(drflac_bs* bs, drflac_u
                 return DRFLAC_FALSE;
             }
             crc8 = drflac_crc8(crc8, header->blockSizeInPCMFrames, 16);
+            if (header->blockSizeInPCMFrames == 0xFFFF) {
+                continue;
+            }
             header->blockSizeInPCMFrames += 1;
         } else {
             DRFLAC_ASSERT(blockSize >= 8);

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -3017,6 +3017,9 @@ The next two functions are responsible for calculating the prediction.
 When the bits per sample is >16 we need to use 64-bit integer arithmetic because otherwise we'll run out of precision. It's
 safe to assume this will be slower on 32-bit platforms so we use a more optimal solution when the bits per sample is <=16.
 */
+#if defined(__clang__)
+__attribute__((no_sanitize("signed-integer-overflow")))
+#endif
 static DRFLAC_INLINE drflac_int32 drflac__calculate_prediction_32(drflac_uint32 order, drflac_int32 shift, const drflac_int32* coefficients, drflac_int32* pDecodedSamples)
 {
     drflac_int32 prediction = 0;
@@ -4799,6 +4802,9 @@ static drflac_bool32 drflac__read_and_seek_residual__rice(drflac_bs* bs, drflac_
     return DRFLAC_TRUE;
 }
 
+#if defined(__clang__)
+__attribute__((no_sanitize("signed-integer-overflow")))
+#endif
 static drflac_bool32 drflac__decode_samples_with_residual__unencoded(drflac_bs* bs, drflac_uint32 bitsPerSample, drflac_uint32 count, drflac_uint8 unencodedBitsPerSample, drflac_uint32 order, drflac_int32 shift, const drflac_int32* coefficients, drflac_int32* pSamplesOut)
 {
     drflac_uint32 i;

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -5270,7 +5270,7 @@ static drflac_bool32 drflac__read_next_flac_frame_header(drflac_bs* bs, drflac_u
             }
             crc8 = drflac_crc8(crc8, header->blockSizeInPCMFrames, 16);
             if (header->blockSizeInPCMFrames == 0xFFFF) {
-                continue;
+                return DRFLAC_FALSE;    /* Frame is too big. This is the size of the frame minus 1. The STREAMINFO block defines the max block size which is 16-bits. Adding one will make it 17 bits and therefore too big. */
             }
             header->blockSizeInPCMFrames += 1;
         } else {

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -2888,6 +2888,16 @@ static DRFLAC_INLINE drflac_bool32 drflac__seek_past_next_set_bit(drflac_bs* bs,
         }
     }
 
+    if (bs->cache == 1) {
+        /* Not catching this would lead to undefined behaviour: a shift of
+         * a 32-bit number by 32 or more is undefined */
+        *pOffsetOut = zeroCounter + (drflac_uint32)DRFLAC_CACHE_L1_BITS_REMAINING(bs) - 1;
+        if (!drflac__reload_cache(bs)) {
+            return DRFLAC_FALSE;
+        }
+        return DRFLAC_TRUE;
+    }
+
     setBitOffsetPlus1 = drflac__clz(bs->cache);
     setBitOffsetPlus1 += 1;
 

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -2889,12 +2889,12 @@ static DRFLAC_INLINE drflac_bool32 drflac__seek_past_next_set_bit(drflac_bs* bs,
     }
 
     if (bs->cache == 1) {
-        /* Not catching this would lead to undefined behaviour: a shift of
-         * a 32-bit number by 32 or more is undefined */
+        /* Not catching this would lead to undefined behaviour: a shift of a 32-bit number by 32 or more is undefined */
         *pOffsetOut = zeroCounter + (drflac_uint32)DRFLAC_CACHE_L1_BITS_REMAINING(bs) - 1;
         if (!drflac__reload_cache(bs)) {
             return DRFLAC_FALSE;
         }
+
         return DRFLAC_TRUE;
     }
 
@@ -5311,8 +5311,7 @@ static drflac_bool32 drflac__read_next_flac_frame_header(drflac_bs* bs, drflac_u
         }
 
         if (header->bitsPerSample != streaminfoBitsPerSample) {
-            /* If this subframe has a different bitsPerSample
-             * then streaminfo or the first frame, reject it */
+            /* If this subframe has a different bitsPerSample then streaminfo or the first frame, reject it */
             return DRFLAC_FALSE;
         }
 

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -5300,6 +5300,12 @@ static drflac_bool32 drflac__read_next_flac_frame_header(drflac_bs* bs, drflac_u
             header->bitsPerSample = streaminfoBitsPerSample;
         }
 
+        if (header->bitsPerSample != streaminfoBitsPerSample) {
+            /* If this subframe has a different bitsPerSample
+             * then streaminfo or the first frame, reject it */
+            return DRFLAC_FALSE;
+        }
+
         if (!drflac__read_uint8(bs, 8, &header->crc8)) {
             return DRFLAC_FALSE;
         }

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -2441,6 +2441,10 @@ static DRFLAC_INLINE drflac_bool32 drflac__read_uint32(drflac_bs* bs, unsigned i
         if (!drflac__reload_cache(bs)) {
             return DRFLAC_FALSE;
         }
+        if (bitCountLo > DRFLAC_CACHE_L1_BITS_REMAINING(bs)) {
+            /* This happens when we get to end of stream */
+            return DRFLAC_FALSE;
+        }
 
         *pResultOut = (resultHi << bitCountLo) | (drflac_uint32)DRFLAC_CACHE_L1_SELECT_AND_SHIFT(bs, bitCountLo);
         bs->consumedBits += bitCountLo;
@@ -2886,6 +2890,11 @@ static DRFLAC_INLINE drflac_bool32 drflac__seek_past_next_set_bit(drflac_bs* bs,
 
     setBitOffsetPlus1 = drflac__clz(bs->cache);
     setBitOffsetPlus1 += 1;
+
+    if (setBitOffsetPlus1 > DRFLAC_CACHE_L1_BITS_REMAINING(bs)) {
+        /* This happens when we get to end of stream */
+        return DRFLAC_FALSE;
+    }
 
     bs->consumedBits += setBitOffsetPlus1;
     bs->cache <<= setBitOffsetPlus1;
@@ -3382,6 +3391,10 @@ static DRFLAC_INLINE drflac_bool32 drflac__read_rice_parts(drflac_bs* bs, drflac
             if (!drflac__reload_cache(bs)) {
                 return DRFLAC_FALSE;
             }
+            if (bitCountLo > DRFLAC_CACHE_L1_BITS_REMAINING(bs)) {
+                /* This happens when we get to end of stream */
+                return DRFLAC_FALSE;
+            }
         }
 
         riceParamPart = (drflac_uint32)(resultHi | DRFLAC_CACHE_L1_SELECT_AND_SHIFT_SAFE(bs, bitCountLo));
@@ -3460,6 +3473,10 @@ static DRFLAC_INLINE drflac_bool32 drflac__read_rice_parts_x1(drflac_bs* bs, drf
             } else {
                 /* Slow path. We need to fetch more data from the client. */
                 if (!drflac__reload_cache(bs)) {
+                    return DRFLAC_FALSE;
+                }
+                if (riceParamPartLoBitCount > DRFLAC_CACHE_L1_BITS_REMAINING(bs)) {
+                    /* This happens when we get to end of stream */
                     return DRFLAC_FALSE;
                 }
 
@@ -3569,6 +3586,11 @@ static DRFLAC_INLINE drflac_bool32 drflac__seek_rice_parts(drflac_bs* bs, drflac
             } else {
                 /* Slow path. We need to fetch more data from the client. */
                 if (!drflac__reload_cache(bs)) {
+                    return DRFLAC_FALSE;
+                }
+
+                if (riceParamPartLoBitCount > DRFLAC_CACHE_L1_BITS_REMAINING(bs)) {
+                    /* This happens when we get to end of stream */
                     return DRFLAC_FALSE;
                 }
 

--- a/tests/flac/fuzz_dr_flac.c
+++ b/tests/flac/fuzz_dr_flac.c
@@ -1,0 +1,76 @@
+/*
+ * Fuzz tester for dr_flac.h
+ *
+ * compile with
+ * clang -g -O1 -fsanitize=fuzzer,address -o fuzz_dr_flac fuzz_dr_flac.c
+ *
+ * and run ./fuzz_dr_flac to run fuzz testing
+ *
+ * Other sanitizers are possible, for example
+ * -fsanitize=fuzzer,memory
+ * -fsanitize=fuzzer,undefined
+ *
+ * For more options, run ./fuzz_dr_flac -help=1
+ *
+ * If a problem is found, the problematic input is saved and can be
+ * rerun (with for example a debugger) with
+ *
+ * ./fuzz_dr_flac file
+ *
+ */
+
+#include <stdint.h>
+
+#define DR_FLAC_IMPLEMENTATION
+#define DR_FLAC_NO_CRC
+#define DR_FLAC_NO_STDIO
+#include "../../dr_flac.h"
+
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
+uint8_t fuzz_flacstream[4096] = {0};
+size_t fuzz_flacstream_position;
+size_t fuzz_flacstream_length;
+
+static size_t read_fuzz_flacstream(void* pUserData, void* bufferOut, size_t bytesToRead)
+{
+    size_t readsize = MIN(bytesToRead, fuzz_flacstream_length-fuzz_flacstream_position);
+    if (readsize > 0) {
+        memcpy(bufferOut, fuzz_flacstream+fuzz_flacstream_position, readsize);
+        fuzz_flacstream_position += readsize;
+        return readsize;
+    } else {
+        return 0;
+    }
+}
+
+static drflac_bool32 seek_fuzz_flacstream(void* pUserData, int offset, drflac_seek_origin origin)
+{
+    if ((int)fuzz_flacstream_position+offset < 0 || (int)fuzz_flacstream_position+offset > fuzz_flacstream_length) {
+        return 1;
+    } else {
+        fuzz_flacstream_position = (int)fuzz_flacstream_position+offset;
+        return 0;
+    }
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size > 2) {
+        drflac * drflac_fuzzer;
+        drflac_int32 drflac_fuzzer_out[2048] = {0}; /* 256 samples over 8 channels */
+        drflac_container container = data[0] & 1 ? drflac_container_native : drflac_container_ogg;
+
+        memcpy(fuzz_flacstream, data, (size-1)<4096?(size-1):4096);
+
+        fuzz_flacstream_position = 0;
+        fuzz_flacstream_length = size-1;
+
+        drflac_fuzzer = drflac_open_relaxed(read_fuzz_flacstream, seek_fuzz_flacstream, container, NULL, NULL);
+
+        while (drflac_read_pcm_frames_s32(drflac_fuzzer, 256, drflac_fuzzer_out));
+
+        drflac_close(drflac_fuzzer);
+    }
+    return 0;
+}


### PR DESCRIPTION
The first commit (41c6caf) of this PR adds a fuzzer to the FLAC tests, which can be build exclusively with clang. It is inspired by (though is not a derivative of) the libFLAC fuzzer. When combined with -fsanitize options it is able to find bugs that can potentially cause security issues.

Commit c51ad32 silences certain (IMO benign) warnings generated when fuzzing with -fsanitize=undefined, the other 5 commits fix various problems found with the fuzzer. I have ran the test program on a set of testvectors with and without these patches on my Raspberry Pi 4 (ARM64) machine, and there seems to be no measureable impact of these patches combined together on decoding speed.

The second of the commits (04552a5), is in my view the most important, because it caused dr_flac to run extremely slow (42s for a fuzz execution where less than 0.1ms is the average), as it could be exploited for a denial-of-service attack.

Commit 066aacf is also important IMO, because it could cause extremely loud, distorted output when a FLAC stream switches to a higher number of bits-per-sample, for example from 16-bit to 24-bit, as the now 24-bit values were shifted left as if they were 16-bit. As the line below already mentiones dr_flac does not support samplerate of channel count changes mid-stream, it seems adding not supporting changing bit per sample to that list would be the most logical solution to this problem.

https://github.com/mackron/dr_libs/blob/4aff56541f5e6bd4b74053a0d5c9e6156e736059/dr_flac.h#L217
