### PR TITLE
tweak DRFLAC_INLINE macro for gcc:

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -1354,19 +1354,16 @@ DRFLAC_API drflac_bool32 drflac_next_cuesheet_track(drflac_cuesheet_track_iterat
 
 #ifdef _MSC_VER
     #define DRFLAC_INLINE __forceinline
-#elif defined(__GNUC__)
+#elif (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 2))) || defined(__clang__)
     /*
     I've had a bug report where GCC is emitting warnings about functions possibly not being inlineable. This warning happens when
     the __attribute__((always_inline)) attribute is defined without an "inline" statement. I think therefore there must be some
     case where "__inline__" is not always defined, thus the compiler emitting these warnings. When using -std=c89 or -ansi on the
-    command line, we cannot use the "inline" keyword and instead need to use "__inline__". In an attempt to work around this issue
-    I am using "__inline__" only when we're compiling in strict ANSI mode.
+    command line, we cannot use the "inline" keyword and instead need to use "__inline__".
     */
-    #if defined(__STRICT_ANSI__)
-        #define DRFLAC_INLINE __inline__ __attribute__((always_inline))
-    #else
-        #define DRFLAC_INLINE inline __attribute__((always_inline))
-    #endif
+    #define DRFLAC_INLINE __inline__ __attribute__((always_inline))
+#elif defined(__GNUC__)
+    #define DRFLAC_INLINE __inline__
 #elif defined(__WATCOMC__)
     #define DRFLAC_INLINE __inline
 #else

--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -226,19 +226,16 @@ typedef drmp3_int32 drmp3_result;
 
 #ifdef _MSC_VER
     #define DRMP3_INLINE __forceinline
-#elif defined(__GNUC__)
+#elif (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 2))) || defined(__clang__)
     /*
     I've had a bug report where GCC is emitting warnings about functions possibly not being inlineable. This warning happens when
     the __attribute__((always_inline)) attribute is defined without an "inline" statement. I think therefore there must be some
     case where "__inline__" is not always defined, thus the compiler emitting these warnings. When using -std=c89 or -ansi on the
-    command line, we cannot use the "inline" keyword and instead need to use "__inline__". In an attempt to work around this issue
-    I am using "__inline__" only when we're compiling in strict ANSI mode.
+    command line, we cannot use the "inline" keyword and instead need to use "__inline__".
     */
-    #if defined(__STRICT_ANSI__)
-        #define DRMP3_INLINE __inline__ __attribute__((always_inline))
-    #else
-        #define DRMP3_INLINE inline __attribute__((always_inline))
-    #endif
+    #define DRMP3_INLINE __inline__ __attribute__((always_inline))
+#elif defined(__GNUC__)
+    #define DRMP3_INLINE __inline__
 #elif defined(__WATCOMC__)
     #define DRMP3_INLINE __inline
 #else

--- a/dr_wav.h
+++ b/dr_wav.h
@@ -1350,19 +1350,16 @@ DRWAV_API drwav_bool32 drwav_fourcc_equal(const drwav_uint8* a, const char* b);
 
 #ifdef _MSC_VER
     #define DRWAV_INLINE __forceinline
-#elif defined(__GNUC__)
+#elif (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 2))) || defined(__clang__)
     /*
     I've had a bug report where GCC is emitting warnings about functions possibly not being inlineable. This warning happens when
     the __attribute__((always_inline)) attribute is defined without an "inline" statement. I think therefore there must be some
     case where "__inline__" is not always defined, thus the compiler emitting these warnings. When using -std=c89 or -ansi on the
-    command line, we cannot use the "inline" keyword and instead need to use "__inline__". In an attempt to work around this issue
-    I am using "__inline__" only when we're compiling in strict ANSI mode.
+    command line, we cannot use the "inline" keyword and instead need to use "__inline__".
     */
-    #if defined(__STRICT_ANSI__)
-        #define DRWAV_INLINE __inline__ __attribute__((always_inline))
-    #else
-        #define DRWAV_INLINE inline __attribute__((always_inline))
-    #endif
+    #define DRWAV_INLINE __inline__ __attribute__((always_inline))
+#elif defined(__GNUC__)
+    #define DRWAV_INLINE __inline__
 #elif defined(__WATCOMC__)
     #define DRWAV_INLINE __inline
 #else


### PR DESCRIPTION
- the `always_inline` attribute is available as of gcc >= 3.1: add version
  checks to avoid warnings from really old gcc.
- `__inline__` is always available in gcc, therefore always use it instead
  of checking for `__STRICT_ANSI__`.