### PR TITLE
dr_flac: Avoid illegal instruction on old systems.

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -1515,9 +1515,7 @@ static DRFLAC_INLINE drflac_bool32 drflac_has_sse41(void)
 {
 #if defined(DRFLAC_SUPPORT_SSE41)
     #if (defined(DRFLAC_X64) || defined(DRFLAC_X86)) && !defined(DRFLAC_NO_SSE41)
-        #if defined(DRFLAC_X64)
-            return DRFLAC_TRUE;    /* 64-bit targets always support SSE4.1. */
-        #elif (defined(_M_IX86_FP) && _M_IX86_FP == 2) || defined(__SSE4_1__)
+        #if defined(__SSE4_1__) || defined(__AVX__)
             return DRFLAC_TRUE;    /* If the compiler is allowed to freely generate SSE41 code we can assume support. */
         #else
             #if defined(DRFLAC_NO_CPUID)


### PR DESCRIPTION
The code on `drflac_has_sse41` seems to be copy pasted from `drflac_has_sse2` and as such I think the detection has some problems. 

```cpp
#if defined(DRFLAC_X64)
            return DRFLAC_TRUE;    /* 64-bit targets always support SSE4.1. */
```
True for SSE2, not necessarily true for SSE4.1

```cpp
 #elif (defined(_M_IX86_FP) && _M_IX86_FP == 2) || defined(__SSE4_1__)
```
`_M_IX86_FP == 2` is true when using `/arch:SSE2` with MSVC but also doesn't seem to define the SSEn macros, yet it does define AVX. 

This code is untested, cuz I'm lazy as I've been using `DRFLAC_NO_SSE41` as a workaround.