### PR TITLE
dr_flac.h: Fixed a "use of uninitializated value" warning

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -6492,7 +6492,7 @@ static drflac_bool32 drflac__read_and_decode_metadata(drflac_read_proc onRead, d
     for (;;) {
         drflac_metadata metadata;
         drflac_uint8 isLastBlock = 0;
-        drflac_uint8 blockType;
+        drflac_uint8 blockType = 0;
         drflac_uint32 blockSize;
         if (drflac__read_and_decode_block_header(onRead, pUserData, &isLastBlock, &blockType, &blockSize) == DRFLAC_FALSE) {
             return DRFLAC_FALSE;


### PR DESCRIPTION
Some compilers do report the absence of initialisation here as a possible use of uninitialized value.