### PR TITLE
dr_mp3.h: Fix typo in comment, 'Introducation' -> 'Introduction'

### DIFF
--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -33,7 +33,7 @@ Support for loading a file from a `wchar_t` string has been added via the `drmp3
 */
 
 /*
-Introducation
+Introduction
 =============
 dr_mp3 is a single file library. To use it, do something like the following in one .c file.
 


### PR DESCRIPTION
This change is useful, if you want to extract the introductory paragraph from dr_{mp3,flac,wav}.h via regular expressions like it's done [here](https://github.com/gentoo/guru/commit/b88d3ed0965aeae7ff98e453e6216e92eaea2f3c#r134692400).