### PR TITLE
Declare the miniaudio submodule as shallow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests/external/miniaudio"]
 	path = tests/external/miniaudio
 	url = https://github.com/dr-soft/miniaudio.git
+	shallow = true


### PR DESCRIPTION
If a repo includes dr_libs as a submodule, a recursive clone would also pull miniaudio with its full history, which currently takes up 157.5 MiB on disk. Declaring miniaudio as shallow would reduce this to 7.4 MiB by only downloading any data needed for the recorded commit. This seems to be a better default for consumers who most likely won't need to jump around in miniaudio's history, if they even build the tests at all. This won't affect existing checkouts, and even new ones can later add back the history via `git fetch --unshallow`.