### PR TITLE
[AIX] Fixing the compilation issue for AIX OS

### DIFF
--- a/dr_flac.h
+++ b/dr_flac.h
@@ -8294,7 +8294,7 @@ static drflac_result drflac_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRFLAC_NOT_IMPLEMENTED;
     #endif
-    #ifdef ENOTEMPTY
+    #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
         case ENOTEMPTY: return DRFLAC_DIRECTORY_NOT_EMPTY;
     #endif
     #ifdef ELOOP

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -8294,6 +8294,7 @@ static drflac_result drflac_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRFLAC_NOT_IMPLEMENTED;
     #endif
+    //In AIX, ENOTEMPTY and EEXIST uses the same value
     #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
         case ENOTEMPTY: return DRFLAC_DIRECTORY_NOT_EMPTY;
     #endif

--- a/dr_flac.h
+++ b/dr_flac.h
@@ -8294,8 +8294,8 @@ static drflac_result drflac_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRFLAC_NOT_IMPLEMENTED;
     #endif
-    //In AIX, ENOTEMPTY and EEXIST uses the same value
-    #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
+    /*In AIX, ENOTEMPTY and EEXIST uses the same value*/
+    #if defined(ENOTEMPTY) && ENOTEMPTY != EEXIST
         case ENOTEMPTY: return DRFLAC_DIRECTORY_NOT_EMPTY;
     #endif
     #ifdef ELOOP

--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -279,7 +279,7 @@ Low Level Push API
 */
 typedef struct
 {
-    int frame_bytes, channels, hz, layer, bitrate_kbps;
+    int frame_bytes, channels, hz_val, layer, bitrate_kbps;
 } drmp3dec_frame_info;
 
 typedef struct
@@ -2296,7 +2296,7 @@ DRMP3_API int drmp3dec_decode_frame(drmp3dec *dec, const drmp3_uint8 *mp3, int m
     DRMP3_COPY_MEMORY(dec->header, hdr, DRMP3_HDR_SIZE);
     info->frame_bytes = i + frame_size;
     info->channels = DRMP3_HDR_IS_MONO(hdr) ? 1 : 2;
-    info->hz = drmp3_hdr_sample_rate_hz(hdr);
+    info->hz_val = drmp3_hdr_sample_rate_hz(hdr);
     info->layer = 4 - DRMP3_HDR_GET_LAYER(hdr);
     info->bitrate_kbps = drmp3_hdr_bitrate_kbps(hdr);
 
@@ -2720,7 +2720,7 @@ static drmp3_uint32 drmp3_decode_next_frame_ex__callbacks(drmp3* pMP3, drmp3d_sa
             pMP3->pcmFramesConsumedInMP3Frame = 0;
             pMP3->pcmFramesRemainingInMP3Frame = pcmFramesRead;
             pMP3->mp3FrameChannels = info.channels;
-            pMP3->mp3FrameSampleRate = info.hz;
+            pMP3->mp3FrameSampleRate = info.hz_val;
             break;
         } else if (info.frame_bytes == 0) {
             /* Need more data. minimp3 recommends doing data submission in 16K chunks. */
@@ -2779,7 +2779,7 @@ static drmp3_uint32 drmp3_decode_next_frame_ex__memory(drmp3* pMP3, drmp3d_sampl
             pMP3->pcmFramesConsumedInMP3Frame  = 0;
             pMP3->pcmFramesRemainingInMP3Frame = pcmFramesRead;
             pMP3->mp3FrameChannels             = info.channels;
-            pMP3->mp3FrameSampleRate           = info.hz;
+            pMP3->mp3FrameSampleRate           = info.hz_val;
             break;
         } else if (info.frame_bytes > 0) {
             /* No frames were read, but it looks like we skipped past one. Read the next MP3 frame. */
@@ -3069,7 +3069,7 @@ static drmp3_result drmp3_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRMP3_NOT_IMPLEMENTED;
     #endif
-    #ifdef ENOTEMPTY
+    #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
         case ENOTEMPTY: return DRMP3_DIRECTORY_NOT_EMPTY;
     #endif
     #ifdef ELOOP

--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -3069,6 +3069,7 @@ static drmp3_result drmp3_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRMP3_NOT_IMPLEMENTED;
     #endif
+    //In AIX, ENOTEMPTY and EEXIST uses the same value
     #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
         case ENOTEMPTY: return DRMP3_DIRECTORY_NOT_EMPTY;
     #endif

--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -279,7 +279,7 @@ Low Level Push API
 */
 typedef struct
 {
-    int frame_bytes, channels, hz_val, layer, bitrate_kbps;
+    int frame_bytes, channels, sample_rate, layer, bitrate_kbps;
 } drmp3dec_frame_info;
 
 typedef struct
@@ -2296,7 +2296,7 @@ DRMP3_API int drmp3dec_decode_frame(drmp3dec *dec, const drmp3_uint8 *mp3, int m
     DRMP3_COPY_MEMORY(dec->header, hdr, DRMP3_HDR_SIZE);
     info->frame_bytes = i + frame_size;
     info->channels = DRMP3_HDR_IS_MONO(hdr) ? 1 : 2;
-    info->hz_val = drmp3_hdr_sample_rate_hz(hdr);
+    info->sample_rate = drmp3_hdr_sample_rate_hz(hdr);
     info->layer = 4 - DRMP3_HDR_GET_LAYER(hdr);
     info->bitrate_kbps = drmp3_hdr_bitrate_kbps(hdr);
 
@@ -2720,7 +2720,7 @@ static drmp3_uint32 drmp3_decode_next_frame_ex__callbacks(drmp3* pMP3, drmp3d_sa
             pMP3->pcmFramesConsumedInMP3Frame = 0;
             pMP3->pcmFramesRemainingInMP3Frame = pcmFramesRead;
             pMP3->mp3FrameChannels = info.channels;
-            pMP3->mp3FrameSampleRate = info.hz_val;
+            pMP3->mp3FrameSampleRate = info.sample_rate;
             break;
         } else if (info.frame_bytes == 0) {
             /* Need more data. minimp3 recommends doing data submission in 16K chunks. */
@@ -2779,7 +2779,7 @@ static drmp3_uint32 drmp3_decode_next_frame_ex__memory(drmp3* pMP3, drmp3d_sampl
             pMP3->pcmFramesConsumedInMP3Frame  = 0;
             pMP3->pcmFramesRemainingInMP3Frame = pcmFramesRead;
             pMP3->mp3FrameChannels             = info.channels;
-            pMP3->mp3FrameSampleRate           = info.hz_val;
+            pMP3->mp3FrameSampleRate           = info.sample_rate;
             break;
         } else if (info.frame_bytes > 0) {
             /* No frames were read, but it looks like we skipped past one. Read the next MP3 frame. */
@@ -3069,8 +3069,8 @@ static drmp3_result drmp3_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRMP3_NOT_IMPLEMENTED;
     #endif
-    //In AIX, ENOTEMPTY and EEXIST uses the same value
-    #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
+    /*In AIX, ENOTEMPTY and EEXIST uses the same value*/
+    #if defined(ENOTEMPTY) && ENOTEMPTY != EEXIST
         case ENOTEMPTY: return DRMP3_DIRECTORY_NOT_EMPTY;
     #endif
     #ifdef ELOOP

--- a/dr_wav.h
+++ b/dr_wav.h
@@ -4704,7 +4704,7 @@ DRWAV_PRIVATE drwav_result drwav_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRWAV_NOT_IMPLEMENTED;
     #endif
-    #ifdef ENOTEMPTY
+    #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
         case ENOTEMPTY: return DRWAV_DIRECTORY_NOT_EMPTY;
     #endif
     #ifdef ELOOP

--- a/dr_wav.h
+++ b/dr_wav.h
@@ -4704,6 +4704,7 @@ DRWAV_PRIVATE drwav_result drwav_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRWAV_NOT_IMPLEMENTED;
     #endif
+    //In AIX, ENOTEMPTY and EEXIST uses the same value
     #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
         case ENOTEMPTY: return DRWAV_DIRECTORY_NOT_EMPTY;
     #endif

--- a/dr_wav.h
+++ b/dr_wav.h
@@ -4704,8 +4704,8 @@ DRWAV_PRIVATE drwav_result drwav_result_from_errno(int e)
     #ifdef ENOSYS
         case ENOSYS: return DRWAV_NOT_IMPLEMENTED;
     #endif
-    //In AIX, ENOTEMPTY and EEXIST uses the same value
-    #if defined(ENOTEMPTY) && ENOTEMPTY!=EEXIST
+    /*In AIX, ENOTEMPTY and EEXIST uses the same value*/
+    #if defined(ENOTEMPTY) && ENOTEMPTY != EEXIST
         case ENOTEMPTY: return DRWAV_DIRECTORY_NOT_EMPTY;
     #endif
     #ifdef ELOOP


### PR DESCRIPTION
We use dr_libs as a part of [https://github.com/microsoft/onnxruntime-extensions](https://github.com/microsoft/onnxruntime-extensions) and observe compilation error.
This PR is having two fixed for compilation error found in AIX OS.

- 
```
In file included from /ranjit/onnxruntime-genai/build/AIX/Release/_deps/onnxruntime_extensions-src/operators/audio/audio_decoder.cc:11:
/ranjit/onnxruntime-genai/build/AIX/Release/_deps/dr_libs-src/dr_flac.h: In function 'drflac_result drflac_result_from_errno(int)':
/ranjit/onnxruntime-genai/build/AIX/Release/_deps/dr_libs-src/dr_flac.h:8298:9: error: duplicate case value
 8298 |         case ENOTEMPTY: return DRFLAC_DIRECTORY_NOT_EMPTY;
      |         ^~~~
/ranjit/onnxruntime-genai/build/AIX/Release/_deps/dr_libs-src/dr_flac.h:8232:9: note: previously used here
 8232 |         case EEXIST: return DRFLAC_ALREADY_EXISTS;
```

This error is caused because in AIX , ENOTEMPTY and EEXIST uses same value.

- 
`/ranjit/onnxruntime-genai/build/AIX/Release/_deps/dr_libs-src/dr_mp3.h:282:32: error: expected unqualified-id before numeric constant
  282 |     int frame_bytes, channels, hz, layer, bitrate_kbps;`
  
  In AIX, hz is a macro define in system level file like below and while processing 'hz' member of drmp3dec_frame_info ,   hz is replaced by pre-processor and causing above error. To fix , this I have used **hz_val** as member of drmp3dec_frame_info
  
```
In AIX /usr/include/sys/m_param.h, 
 
#define _HZ 100     /* ticks per second of the clock    */
#define __hz    HZ      /* Berkeley uses lower case hz      */
#define hz __hz
```

