### PR TITLE
dr_mp3: Fix seek table generation with memory buffers instead of i/o callbacks.

### DIFF
--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -2883,6 +2883,7 @@ static drmp3_uint32 drmp3_decode_next_frame_ex__memory(drmp3* pMP3, drmp3d_sampl
 
     /* Consume the data. */
     pMP3->memory.currentReadPos += (size_t)info.frame_bytes;
+    pMP3->streamCursor += (size_t)info.frame_bytes;
 
     return pcmFramesRead;
 }


### PR DESCRIPTION

drmp3_calculate_seek_points() builds the table with file positions like this:

```c
mp3FrameInfo[iMP3Frame].bytePos = pMP3->streamCursor - pMP3->dataSize;
```

drmp3_decode_next_frame_ex__callbacks() updates both streamCursor and dataSize, but drmp3_decode_next_frame_ex__memory() does not, so all entries in the seek table end up pointing at the start of the audio file.

This patch updates streamCursor as we read more bytes, but leaves dataSize at zero, since the latter appears to be how much is left to consume of the existing read buffer before more is read from disk, so subtracting zero in drmp3_calculate_seek_points() is the correct thing to do when reading entirely from memory.

Fixes #278.
