### PR TITLE
bext size allocation error

### DIFF
--- a/dr_wav.h
+++ b/dr_wav.h
@@ -2811,7 +2811,7 @@ DRWAV_PRIVATE drwav_uint64 drwav__metadata_process_chunk(drwav__metadata_parser*
                     return bytesRead;
                 }
                 allocSizeNeeded += drwav__strlen(buffer) + 1;
-                allocSizeNeeded += (size_t)pChunkHeader->sizeInBytes - DRWAV_BEXT_BYTES; /* Coding history. */
+                allocSizeNeeded += (size_t)pChunkHeader->sizeInBytes - DRWAV_BEXT_BYTES + 1; /* Coding history. */
 
                 drwav__metadata_request_extra_memory_for_stage_2(pParser, allocSizeNeeded, 1);
 


### PR DESCRIPTION
on line 2531 the reader consumes one byte too much (extraBytes + 1). This can cause a DRWAV_ASSERT.
This fix adds the missing byte to the extraCapacity in stage 1.