### PR TITLE
Fixed the issue of returning a wild pointer when MP3 memory allocatio…

### DIFF
--- a/dr_mp3.h
+++ b/dr_mp3.h
@@ -4804,6 +4804,10 @@ static float* drmp3__full_read_and_close_f32(drmp3* pMP3, drmp3_config* pConfig,
             pNewFrames = (float*)drmp3__realloc_from_callbacks(pFrames, (size_t)newFramesBufferSize, (size_t)oldFramesBufferSize, &pMP3->allocationCallbacks);
             if (pNewFrames == NULL) {
                 drmp3__free_from_callbacks(pFrames, &pMP3->allocationCallbacks);
+                pFrames = NULL;
+                totalFramesRead = 0;
+                pConfig = NULL;
+                pTotalFrameCount = NULL;
                 break;
             }
 
@@ -4871,6 +4875,10 @@ static drmp3_int16* drmp3__full_read_and_close_s16(drmp3* pMP3, drmp3_config* pC
             pNewFrames = (drmp3_int16*)drmp3__realloc_from_callbacks(pFrames, (size_t)newFramesBufferSize, (size_t)oldFramesBufferSize, &pMP3->allocationCallbacks);
             if (pNewFrames == NULL) {
                 drmp3__free_from_callbacks(pFrames, &pMP3->allocationCallbacks);
+                pFrames = NULL;
+                totalFramesRead = 0;
+                pConfig = NULL;
+                pTotalFrameCount = NULL;
                 break;
             }
 


### PR DESCRIPTION
Fixed the issue of returning a wild pointer when MP3 memory allocation fails during reading.