### PR TITLE
dr_wav: Validate ADPCM block header size against data chunk size

### DIFF
--- a/dr_wav.h
+++ b/dr_wav.h
@@ -3826,6 +3826,11 @@ DRWAV_PRIVATE drwav_bool32 drwav_init__internal(drwav* pWav, drwav_chunk_proc on
             drwav_uint64 totalBlockHeaderSizeInBytes;
             drwav_uint64 blockCount = dataChunkSize / fmt.blockAlign;
 
+            if (dataChunkSize < totalBlockHeaderSizeInBytes) {
+                drwav_free(pWav->pMetadata, &pWav->allocationCallbacks);
+                return DRWAV_FALSE; /* Invalid file. */
+            }
+
             /* Make sure any trailing partial block is accounted for. */
             if ((blockCount * fmt.blockAlign) < dataChunkSize) {
                 blockCount += 1;


### PR DESCRIPTION
Add a guard to ensure `dataChunkSize` is not smaller than the calculated total block header size (`blockCount * (6 * fmt.channels)`) when parsing ADPCM data. If the header size exceeds the data chunk size, the file is invalid, so metadata is freed and initialization fails early.

This prevents underflow in the PCM frame count calculation and avoids processing malformed or truncated WAV files.

----

this file would end up with an invalid totalPCMFrameCount: 
[notification.wav](https://github.com/user-attachments/files/25783324/notification.wav)
