### PR TITLE
Fix infinite loop in drwav_init on a malformed `fmt ` chunk size

### DIFF
--- a/dr_wav.h
+++ b/dr_wav.h
@@ -3406,7 +3406,7 @@ DRWAV_PRIVATE drwav_bool32 drwav_init__internal(drwav* pWav, drwav_chunk_proc on
                 }
 
                 /* Seek past any leftover bytes. For w64 the leftover will be defined based on the chunk size. */
-                if (pWav->onSeek(pWav->pUserData, (int)(header.sizeInBytes - bytesReadSoFar), DRWAV_SEEK_CUR) == DRWAV_FALSE) {
+                if (drwav__seek_forward(pWav->onSeek, header.sizeInBytes - bytesReadSoFar, pWav->pUserData) == DRWAV_FALSE) {
                     return DRWAV_FALSE;
                 }
                 cursor += (header.sizeInBytes - bytesReadSoFar);


### PR DESCRIPTION
A WAV with a `fmt ` chunk whose size field is near 0xFFFFFFFF sends `drwav_init` into an infinite loop. The leftover-bytes skip casts the chunk size straight to `int`:

    (int)(header.sizeInBytes - bytesReadSoFar)

With a size like 0xFFFFFFF7 that becomes a small negative number, so the seek goes backwards instead of forwards and succeeds (it stays inside the buffer). The chunk loop then re-reads the same spot forever and never reaches EOF. A 39 byte file is enough to hang it.

This routes the skip through `drwav__seek_forward()` instead, the same helper the other large seeks already use. It walks the offset through a `drwav_uint64` so it can't wrap an `int`, and an oversized skip now fails cleanly and breaks the loop.

Tested: the hanging samples all return immediately after the change, and every valid WAV I had still decodes the same as before.