### PR TITLE
tests: Fix libsndfile loading on macOS.

### DIFF
--- a/tests/wav/wav_common.c
+++ b/tests/wav/wav_common.c
@@ -32,6 +32,9 @@ drwav_result libsndfile_init_api(void)
         "libsndfile-1-x86.dll",
     #endif
         "libsndfile-1.dll"
+#elif defined(__APPLE__)
+        "libsndfile.1.dylib",
+        "libsndfile.dylib"
 #else
         "libsndfile-1.so",
         "libsndfile.so.1"


### PR DESCRIPTION
libsndfile's dylib is called `libsndfile.1.dylib` or `libsndfile.dylib` on macOS (as distributed in Homebrew). The current code fails to find it, causing the wav_decoding tests to fail:

```
$ /opt/homebrew/bin/cmake -S . -B build -DDR_LIBS_BUILD_TESTS=ON
$ /opt/homebrew/bin/cmake --build build --target wav_decoding
$ DYLD_LIBRARY_PATH=/opt/homebrew/lib ./build/wav_decoding
Failed to initialize libsndfile API.
```

Fix it so the tests pass on macOS:
```
$ DYLD_LIBRARY_PATH=/opt/homebrew/lib ./build/wav_decoding
=======================================================================
DECODE TESTING
=======================================================================
tests/testvectors/wav/tests               RESULT
  alaw_mono_8k.wav                        Passed
  adpcm_ima_mono_16k.wav                  Passed
  s16_stereo_44k.wav                      Passed
  mulaw_mono_8k.wav                       Passed
  s16_meta_44k.wav                        Passed
  u8_mono_8k.wav                          Passed
  s16_mono_44k.wav                        Passed
  s24_stereo_48k.wav                      Passed
  s16_5p1_48k.wav                         Passed
  f32_stereo_48k.wav                      Passed
  adpcm_ms_stereo_22k.wav                 Passed
  test.wav                                Passed
  s32_stereo_48k.wav                      Passed
  f64_mono_22k.wav                        Passed

=======================================================================
DECODE PROFILING (LOWER IS BETTER)
=======================================================================
```