### PR TITLE
tests: Fix path to miniaudio.h.

### DIFF
--- a/tests/wav/wav_playback.c
+++ b/tests/wav/wav_playback.c
@@ -1,7 +1,7 @@
 #define MA_NO_DECODING
 #define MA_NO_ENCODING
 #define MA_IMPLEMENTATION
-#include "../../../miniaudio/miniaudio.h"
+#include "../external/miniaudio/miniaudio.h"
 
 #define DR_WAV_IMPLEMENTATION
 #include "../../dr_wav.h"


### PR DESCRIPTION
wav_playback.c includes a copy of miniaudio.h that lives outside of dr_libs's checkout. Use the miniaudio.h from tests/external/miniaudio instead, mimicking tests/mp3/mp3_playback.c.