### PR TITLE
build: Fix linking to FLAC discovered via find_library().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,8 @@ if(NOT DR_LIBS_NO_FLAC)
             find_library(FLAC FLAC)
             if(FLAC)
                 message(STATUS "libFLAC found. Building FLAC tests.")
+                add_library(FLAC UNKNOWN IMPORTED)
+                set_target_properties(FLAC PROPERTIES IMPORTED_LOCATION "${FLAC}")
                 set(HAS_FLAC TRUE)
             else()
                 # As a last resort, look in the tests/external/flac folder.


### PR DESCRIPTION
In the successful find_library() code path, the ${FLAC} variable is defined. But that variable not used by add_flac_test(), which assumes that there is a target or library called 'FLAC'. add_flac_test() either ends up using the wrong FLAC library or causes link errors (-lFLAC not found).

Fix the problem by defining a target called 'FLAC' when find_library() succeeds.