### PR TITLE
dr_wav: shift through unsigned when widening samples to s32

### DIFF
--- a/dr_wav.h
+++ b/dr_wav.h
@@ -8099,7 +8099,7 @@ DRWAV_API void drwav_u8_to_s32(drwav_int32* pOut, const drwav_uint8* pIn, size_t
     }
 
     for (i = 0; i < sampleCount; ++i) {
-        *pOut++ = ((int)pIn[i] - 128) << 24;
+        *pOut++ = (drwav_int32)((drwav_uint32)((int)pIn[i] - 128) << 24);
     }
 }
 
@@ -8112,7 +8112,7 @@ DRWAV_API void drwav_s16_to_s32(drwav_int32* pOut, const drwav_int16* pIn, size_
     }
 
     for (i = 0; i < sampleCount; ++i) {
-        *pOut++ = pIn[i] << 16;
+        *pOut++ = (drwav_int32)((drwav_uint32)pIn[i] << 16);
     }
 }
 
@@ -8169,7 +8169,7 @@ DRWAV_API void drwav_alaw_to_s32(drwav_int32* pOut, const drwav_uint8* pIn, size
     }
 
     for (i = 0; i < sampleCount; ++i) {
-        *pOut++ = ((drwav_int32)drwav__alaw_to_s16(pIn[i])) << 16;
+        *pOut++ = (drwav_int32)((drwav_uint32)drwav__alaw_to_s16(pIn[i]) << 16);
     }
 }
 
@@ -8182,7 +8182,7 @@ DRWAV_API void drwav_mulaw_to_s32(drwav_int32* pOut, const drwav_uint8* pIn, siz
     }
 
     for (i= 0; i < sampleCount; ++i) {
-        *pOut++ = ((drwav_int32)drwav__mulaw_to_s16(pIn[i])) << 16;
+        *pOut++ = (drwav_int32)((drwav_uint32)drwav__mulaw_to_s16(pIn[i]) << 16);
     }
 }
 


### PR DESCRIPTION
### What

The four s32 conversion helpers left shift a signed value:

```c
*pOut++ = ((int)pIn[i] - 128) << 24;                         /* u8    8102 */
*pOut++ = pIn[i] << 16;                                      /* s16   8115 */
*pOut++ = ((drwav_int32)drwav__alaw_to_s16(pIn[i])) << 16;   /* alaw  8172 */
*pOut++ = ((drwav_int32)drwav__mulaw_to_s16(pIn[i])) << 16;  /* mulaw 8185 */
```

Left shifting a negative value is undefined behaviour.

This is not a malformed-input case — it happens for **ordinary audio**. Any u8 sample below 128, and any negative s16, A-law or μ-law sample, hits it, so a UBSan build reports while decoding a perfectly valid file:

```
dr_wav.h:8115:26: runtime error: left shift of negative value -1473
dr_wav.h:8102:39: runtime error: left shift of negative value -128
dr_wav.h:8172:61: runtime error: left shift of negative value
dr_wav.h:8185:62: runtime error: left shift of negative value
```

Only the `s32` output path is affected; `drwav_read_pcm_frames_f32` goes elsewhere and is clean, which is probably why it has stayed quiet.

### The change

Do the shift in `drwav_uint32` and convert back. Same bits, defined behaviour.

`drwav_s24_to_s32` deliberately untouched — its `s0`/`s1`/`s2` are already `unsigned int`, so it is fine as written.

### Verification

Fifteen files covering u8, s16, s24, s32, A-law, μ-law, IMA ADPCM, MS ADPCM and several metadata-chunk variants, decoded fully through `drwav_read_pcm_frames_s32` with the entire output stream hashed:

- **before:** 6 of them produce UBSan reports
- **after:** none do
- **decoded output: identical hashes on all fifteen**

### How it was found

I was fuzzing `dr_wav` and noticed there is a fuzz harness for dr_flac (`tests/flac/flac_fuzz.c`) but none for dr_wav or dr_mp3. So I wrote one in the same shape as yours — libFuzzer entry point, `drwav_init_memory_with_metadata` so the chunk parsers are covered, then decode — and these reports came out of ordinary corpus files rather than mutated ones.

2500 mutation iterations plus 17 hand-built malformed headers (chunks declaring more content than they hold, zero channels, zero `blockAlign`, absurd sample rates, oversized `cue`/`smpl`/`LIST`) found **nothing else** — dr_wav held up well against all of it.

Happy to send that harness as a separate PR if you would like it in `tests/wav/`. One caveat if I do: this machine's Xcode toolchain has no `libclang_rt.fuzzer_osx.a`, so I could not link `-fsanitize=fuzzer` here. I exercised the harness body through a small driver that feeds it files instead, so the code is tested but the libFuzzer line itself is not — it is identical in form to the one in `flac_fuzz.c`.

Separately and unverified: `dr_flac.h:9629-9630` shift `(mid + side)` and `(mid - side)` which look signed. I have not demonstrated those, so I have left them alone rather than guess.

### Disclosure

Written with Claude Code assisting, under my direction; the commit carries an `Assisted-By` trailer. I verified the before/after myself on macOS/arm64.

X: manuaudiomix
