### PR TITLE
tests: add fuzzing harnesses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,14 @@ cmake_minimum_required(VERSION 3.10)
 project(dr_libs)
 
 # Options
-option(DR_LIBS_BUILD_TESTS      "Build tests"              OFF)
-option(DR_LIBS_FORCE_CXX        "Force compilation as C++" OFF)
-option(DR_LIBS_FORCE_C89        "Force compilation as C89" OFF)
-option(DR_LIBS_SANITIZE_ADDRESS "Enable AddressSanitizer"  OFF)
-option(DR_LIBS_NO_WAV           "Disable WAV"              OFF)
-option(DR_LIBS_NO_FLAC          "Disable FLAC"             OFF)
-option(DR_LIBS_NO_MP3           "Disable MP3"              OFF)
+option(DR_LIBS_BUILD_TESTS      "Build tests"               OFF)
+option(DR_LIBS_FORCE_CXX        "Force compilation as C++"  OFF)
+option(DR_LIBS_FORCE_C89        "Force compilation as C89"  OFF)
+option(DR_LIBS_SANITIZE_ADDRESS "Enable AddressSanitizer"   OFF)
+option(DR_LIBS_NO_WAV           "Disable WAV"               OFF)
+option(DR_LIBS_NO_FLAC          "Disable FLAC"              OFF)
+option(DR_LIBS_NO_MP3           "Disable MP3"               OFF)
+option(DR_LIBS_BUILD_FUZZERS    "Build libFuzzer harnesses" OFF)
 
 # Construct compiler flags.
 set(COMPILE_OPTIONS)
@@ -76,6 +77,26 @@ if(UNIX)
 endif()
 
 
+if(DR_LIBS_BUILD_FUZZERS)
+    if(DEFINED ENV{LIB_FUZZING_ENGINE})
+        set(DR_LIBS_FUZZING_ENGINE $ENV{LIB_FUZZING_ENGINE})
+    else()
+        if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            message(WARNING "DR_LIBS_BUILD_FUZZERS: LIB_FUZZING_ENGINE is not set and the compiler is not Clang; defaulting to -fsanitize=fuzzer, which requires Clang.")
+        endif()
+        set(DR_LIBS_FUZZING_ENGINE "-fsanitize=fuzzer,address")
+    endif()
+
+    function(add_dr_libs_fuzzer name source)
+        add_executable(${name} ${source})
+        if(NOT DEFINED ENV{LIB_FUZZING_ENGINE})
+            target_compile_options(${name} PRIVATE -fsanitize=fuzzer,address)
+        endif()
+        target_link_libraries(${name} PRIVATE ${COMMON_LIBRARIES} ${DR_LIBS_FUZZING_ENGINE})
+    endfunction()
+endif()
+
+
 # WAV
 if(NOT DR_LIBS_NO_WAV)
     if(DR_LIBS_BUILD_TESTS)
@@ -120,6 +141,10 @@ if(NOT DR_LIBS_NO_WAV)
         endif()
     else()
         # Not building tests.
+    endif()
+
+    if(DR_LIBS_BUILD_FUZZERS)
+        add_dr_libs_fuzzer(dr_wav_fuzzer tests/wav/dr_wav_fuzzer.cc)
     endif()
 endif()
 
@@ -175,6 +200,10 @@ if(NOT DR_LIBS_NO_FLAC)
     else()
         # Not building tests.
     endif()
+
+    if(DR_LIBS_BUILD_FUZZERS)
+        add_dr_libs_fuzzer(dr_flac_fuzzer tests/flac/dr_flac_fuzzer.cc)
+    endif()
 endif()
 
 
@@ -196,5 +225,9 @@ if(NOT DR_LIBS_NO_MP3)
         add_test(NAME mp3_extract COMMAND mp3_extract ${CMAKE_CURRENT_SOURCE_DIR}/tests/testvectors/mp3/tests/test.mp3 -o ${CMAKE_CURRENT_BINARY_DIR}/test.mp3)
     else()
         # Not building tests.
+    endif()
+
+    if(DR_LIBS_BUILD_FUZZERS)
+        add_dr_libs_fuzzer(dr_mp3_fuzzer tests/mp3/dr_mp3_fuzzer.cc)
     endif()
 endif()

--- a/tests/flac/dr_flac_fuzzer.cc
+++ b/tests/flac/dr_flac_fuzzer.cc
@@ -1,0 +1,33 @@
+/*
+ * libFuzzer harness for dr_flac.h
+ *
+ * compile with
+ * clang++ -g -O1 -std=c++11 -fsanitize=fuzzer,address -o dr_flac_fuzzer tests/flac/dr_flac_fuzzer.cc
+ *
+ * and run ./dr_flac_fuzzer to run fuzz testing. For more options, run ./dr_flac_fuzzer -help=1
+ */
+#include <cstdint>
+
+#define DR_FLAC_IMPLEMENTATION
+#include "../../dr_flac.h"
+
+namespace {
+constexpr drflac_uint64 kMaxFramesPerRead = 4096;
+constexpr int kMaxChannels = 8; /* FLAC spec limit */
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    drflac *pFlac = drflac_open_memory(data, size, nullptr);
+    if (pFlac == nullptr) {
+        return 0;
+    }
+
+    static drflac_int32 buffer[kMaxFramesPerRead * kMaxChannels];
+    drflac_uint64 framesRead;
+    do {
+        framesRead = drflac_read_pcm_frames_s32(pFlac, kMaxFramesPerRead, buffer);
+    } while (framesRead == kMaxFramesPerRead);
+
+    drflac_close(pFlac);
+    return 0;
+}

--- a/tests/mp3/dr_mp3_fuzzer.cc
+++ b/tests/mp3/dr_mp3_fuzzer.cc
@@ -1,0 +1,33 @@
+/*
+ * libFuzzer harness for dr_mp3.h
+ *
+ * compile with
+ * clang++ -g -O1 -std=c++11 -fsanitize=fuzzer,address -o dr_mp3_fuzzer tests/mp3/dr_mp3_fuzzer.cc
+ *
+ * and run ./dr_mp3_fuzzer to run fuzz testing. For more options, run ./dr_mp3_fuzzer -help=1
+ */
+#include <cstdint>
+
+#define DR_MP3_IMPLEMENTATION
+#include "../../dr_mp3.h"
+
+namespace {
+constexpr drmp3_uint64 kMaxFramesPerRead = 4096;
+constexpr int kMaxChannels = 2; /* MP3 spec limit: mono or stereo */
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    drmp3 mp3;
+    if (!drmp3_init_memory(&mp3, data, size, nullptr)) {
+        return 0;
+    }
+
+    static float buffer[kMaxFramesPerRead * kMaxChannels];
+    drmp3_uint64 framesRead;
+    do {
+        framesRead = drmp3_read_pcm_frames_f32(&mp3, kMaxFramesPerRead, buffer);
+    } while (framesRead == kMaxFramesPerRead);
+
+    drmp3_uninit(&mp3);
+    return 0;
+}

--- a/tests/wav/dr_wav_fuzzer.cc
+++ b/tests/wav/dr_wav_fuzzer.cc
@@ -1,0 +1,32 @@
+/*
+ * libFuzzer harness for dr_wav.h
+ *
+ * compile with
+ * clang++ -g -O1 -std=c++11 -fsanitize=fuzzer,address -o dr_wav_fuzzer tests/wav/dr_wav_fuzzer.cc
+ *
+ * and run ./dr_wav_fuzzer to run fuzz testing. For more options, run ./dr_wav_fuzzer -help=1
+ */
+#include <cstdint>
+
+#define DR_WAV_IMPLEMENTATION
+#include "../../dr_wav.h"
+
+namespace {
+constexpr drwav_uint64 kMaxFramesPerRead = 4096;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    drwav wav;
+    if (!drwav_init_memory(&wav, data, size, nullptr)) {
+        return 0;
+    }
+
+    static drwav_int16 buffer[kMaxFramesPerRead * DRWAV_MAX_CHANNELS];
+    drwav_uint64 framesRead;
+    do {
+        framesRead = drwav_read_pcm_frames_s16(&wav, kMaxFramesPerRead, buffer);
+    } while (framesRead == kMaxFramesPerRead);
+
+    drwav_uninit(&wav);
+    return 0;
+}


### PR DESCRIPTION
Adding fuzzing harnesses to the tests. They are set up in a way that they can be used with google's oss-fuzz infrastructure.